### PR TITLE
Rconsense can now handle ompetely unresolved consensus trees

### DIFF
--- a/Rphylip.R
+++ b/Rphylip.R
@@ -1821,8 +1821,12 @@ Rconsense<-function(trees,path=NULL,...){
 	tree$tip.label<-tip.label[as.numeric(tree$tip.label)]
 	temp<-readLines("outfile")
 	if(!is.null(tree$edge.length)){
-		tree$node.label<-c(NA,tree$edge.length[sapply(2:tree$Nnode+length(tree$tip.label),function(x,y) which(y==x),y=tree$edge[,2])]/length(trees))
-		tree$edge.length<-NULL
+            if(tree$Nnode > 1){
+                tree$node.label <-c(NA, tree$edge.length[sapply(2:tree$Nnode + length(tree$tip.label), function(x, y) which(y ==  x), y = tree$edge[, 2])]/length(trees))
+            }else{
+                tree$node.label <-c(NA)
+            }
+            tree$edge.length<-NULL
 	}
 	if(!rooted) tree<-unroot(tree)
 	if(!quiet) temp<-lapply(temp,function(x) { cat(x); cat("\n") })

--- a/Rphylip/DESCRIPTION
+++ b/Rphylip/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rphylip
-Version: 0.1-26
+Version: 0.1-26-1
 Date: 2014-8-8
 Title: An R interface for PHYLIP
 Author: Liam J. Revell, Scott A. Chamberlain

--- a/Rphylip/R/Rphylip.R
+++ b/Rphylip/R/Rphylip.R
@@ -1821,8 +1821,12 @@ Rconsense<-function(trees,path=NULL,...){
 	tree$tip.label<-tip.label[as.numeric(tree$tip.label)]
 	temp<-readLines("outfile")
 	if(!is.null(tree$edge.length)){
-		tree$node.label<-c(NA,tree$edge.length[sapply(2:tree$Nnode+length(tree$tip.label),function(x,y) which(y==x),y=tree$edge[,2])]/length(trees))
-		tree$edge.length<-NULL
+            if(tree$Nnode > 1){
+                tree$node.label <-c(NA, tree$edge.length[sapply(2:tree$Nnode + length(tree$tip.label), function(x, y) which(y ==  x), y = tree$edge[, 2])]/length(trees))
+            }else{
+                tree$node.label <-c(NA)
+            }
+            tree$edge.length<-NULL
 	}
 	if(!rooted) tree<-unroot(tree)
 	if(!quiet) temp<-lapply(temp,function(x) { cat(x); cat("\n") })


### PR DESCRIPTION
@liamrevell 
I have used Rphylip in a project and noticed that when the consensus tree from phylip's consense method is completely unresolved, then Rconsense fails when reformatting the tree to a phylo object. 

Briefly, when the outtree file from phylip's consense is read, the bootstrap values are stored in tree$edge.length; Rconsense attempts to moves these to tree$node.label. However, Rconsense then assumes that there are at least two internal nodes and, therefore, fails when there are fewer internal nodes (as is the case for a completely unresolved tree which has only one internal node, the root).
In this proposed change, I have added an additional if clause that handles the case with a single internal (root) node. 

I have chosen to communicate this as a pull request. Please let me know how you want to handle this.

Some additional info: 
1) To simplify testing, I modified the version number in Rphylip/DESCRIPTION, adding a "-1" (i.e., from "Version: 0.1-26" to "Version: 0.1-26-1"). This is probably not your preferred way, and need to be fixed.
Let me know if/how I should change this.
2) I have made bioconda recipes for both Phylip and Rphylip for use in one of our projects. I could have made this change as a patch, but I felt would be much better to fix it in the source code if this could be done quickly. Let me know if this is not the case.

I hope you will have use of this proposed change to improve the Rphylip package -- it is a great package! Thank you for providing it.