### PR TITLE
Read.multi.xx fix

### DIFF
--- a/Rphylip.R
+++ b/Rphylip.R
@@ -1821,8 +1821,12 @@ Rconsense<-function(trees,path=NULL,...){
 	tree$tip.label<-tip.label[as.numeric(tree$tip.label)]
 	temp<-readLines("outfile")
 	if(!is.null(tree$edge.length)){
-		tree$node.label<-c(NA,tree$edge.length[sapply(2:tree$Nnode+length(tree$tip.label),function(x,y) which(y==x),y=tree$edge[,2])]/length(trees))
-		tree$edge.length<-NULL
+            if(tree$Nnode > 1){
+                tree$node.label <-c(NA, tree$edge.length[sapply(2:tree$Nnode + length(tree$tip.label), function(x, y) which(y ==  x), y = tree$edge[, 2])]/length(trees))
+            }else{
+                tree$node.label <-c(NA)
+            }
+            tree$edge.length<-NULL
 	}
 	if(!rooted) tree<-unroot(tree)
 	if(!quiet) temp<-lapply(temp,function(x) { cat(x); cat("\n") })

--- a/Rphylip/DESCRIPTION
+++ b/Rphylip/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rphylip
-Version: 0.1-26
+Version: 0.1-26-1
 Date: 2014-8-8
 Title: An R interface for PHYLIP
 Author: Liam J. Revell, Scott A. Chamberlain

--- a/Rphylip/R/Rphylip.R
+++ b/Rphylip/R/Rphylip.R
@@ -1821,8 +1821,12 @@ Rconsense<-function(trees,path=NULL,...){
 	tree$tip.label<-tip.label[as.numeric(tree$tip.label)]
 	temp<-readLines("outfile")
 	if(!is.null(tree$edge.length)){
-		tree$node.label<-c(NA,tree$edge.length[sapply(2:tree$Nnode+length(tree$tip.label),function(x,y) which(y==x),y=tree$edge[,2])]/length(trees))
-		tree$edge.length<-NULL
+            if(tree$Nnode > 1){
+                tree$node.label <-c(NA, tree$edge.length[sapply(2:tree$Nnode + length(tree$tip.label), function(x, y) which(y ==  x), y = tree$edge[, 2])]/length(trees))
+            }else{
+                tree$node.label <-c(NA)
+            }
+            tree$edge.length<-NULL
 	}
 	if(!rooted) tree<-unroot(tree)
 	if(!quiet) temp<-lapply(temp,function(x) { cat(x); cat("\n") })

--- a/Rphylip/R/Rphylip.R
+++ b/Rphylip/R/Rphylip.R
@@ -3,7 +3,8 @@
 
 read.multi.dna<-function(file,N,n){
 	FF<-readLines(file)
-	skip<-grep(pattern=paste("   ",n,sep=""),FF)-1
+	nspc<-5-nchar(n)
+	skip<-grep(pattern=paste(strrep(" ",nspc),n,sep=""),FF)-1
 	X<-lapply(skip,read.dna,file=file,format="sequential")
 	return(X)
 }
@@ -13,7 +14,8 @@ read.multi.dna<-function(file,N,n){
 
 read.multi.phylip.data<-function(file,N,n){
 	FF<-readLines(file)
-	skip<-grep(pattern=paste("   ",n,sep=""),FF)-1
+	nspc<-5-nchar(n)
+	skip<-grep(pattern=paste(strrep(" ",nspc),n,sep=""),FF)-1
 	X<-lapply(skip,read.phylip.data,file=file,format="sequential")
 	return(X)
 }
@@ -23,7 +25,8 @@ read.multi.phylip.data<-function(file,N,n){
 
 read.multi.rest.data<-function(file,N,n){
 	FF<-readLines(file)
-	skip<-grep(pattern=paste("   ",n,sep=""),FF)-1
+	nspc<-5-nchar(n)
+	skip<-grep(pattern=paste(strrep(" ",nspc),n,sep=""),FF)-1
 	X<-lapply(skip,read.rest.data,file=file)
 	return(X)
 }
@@ -365,7 +368,8 @@ print.rest.data<-function(x,printlen=6,digits=3,...){
 ## written by Liam J. Revell 2014
 
 write.rest.data<-function(X,append=FALSE){
-	write(paste("    ",length(X),"   ",attr(X,"nsites"),"   ",attr(X,"nenzymes"),sep=""),file="infile",append=append)
+	nspc<-5-nchar(nrow(X))
+	write(paste(strrep(" ",nspc),length(X),"   ",attr(X,"nsites"),"   ",attr(X,"nenzymes"),sep=""),file="infile",append=append)
 	for(i in 1:length(X)){
 		sp<-as.character(i)
 		sp<-paste(sp,paste(rep(" ",11-nchar(sp)),collapse=""),collapse="")
@@ -2220,7 +2224,8 @@ Rthreshml<-function(tree,X,types=NULL,path=NULL,...){
 
 write.continuous<-function(X,append=FALSE){
 	if(is.vector(X)) X<-as.matrix(X)
-	write(paste("    ",nrow(X),"   ",ncol(X),sep=""),file="infile",append=append)
+	nspc<-5-nchar(nrow(X))
+	write(paste(strrep(" ",nspc),nrow(X),"   ",ncol(X),sep=""),file="infile",append=append)
 	for(i in 1:nrow(X)){
 		sp<-as.character(i)
 		sp<-paste(sp,paste(rep(" ",11-nchar(sp)),collapse=""),collapse="")
@@ -2325,7 +2330,8 @@ Rneighbor<-function(D,path=NULL,...){
 ## written by Liam J. Revell 2013
 
 write.distances<-function(D){
-	write(paste("    ",nrow(D),sep=""),file="infile")
+	nspc<-5-nchar(nrow(D))
+	write(paste(strrep(" ",nspc),nrow(D),sep=""),file="infile")
 	for(i in 1:nrow(D)){
 		sp<-as.character(i)
 		sp<-paste(sp,paste(rep(" ",11-nchar(sp)),collapse=""),collapse="")
@@ -2435,7 +2441,8 @@ findPath<-function(string){
 ## written by Liam J. Revell 2013
 
 write.dna<-function(X,append=FALSE){
-	write(paste("    ",nrow(X),"   ",ncol(X),sep=""),file="infile",append=append)
+	nspc<-5-nchar(nrow(X))
+	write(paste(strrep(" ",nspc),nrow(X),"   ",ncol(X),sep=""),file="infile",append=append)
 	for(i in 1:nrow(X)){
 		sp<-as.character(i)
 		sp<-paste(sp,paste(rep(" ",11-nchar(sp)),collapse=""),collapse="")


### PR DESCRIPTION
The space padding implemented for several read.xx functions fails when ntaxa > 99 (i.e. take up more than two digits). This PR fixes this.